### PR TITLE
add ffmpeg to docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM jrottenberg/ffmpeg:4-ubuntu
 
 RUN \
     apt update && \
@@ -10,8 +10,11 @@ RUN \
     rm -rf pingos && \
     apt autoclean && apt autoremove && \
     rm -rf /var/lib/apt/lists/* && \
-    rm -rf /var/cache/apt/*
+    rm -rf /var/cache/apt/* && \
+    cp /usr/local/bin/ffmpeg /usr/bin
 
 WORKDIR /usr/local/pingos/
 
-CMD ["./sbin/nginx", "-g", "daemon off;"]
+ENTRYPOINT [ "./sbin/nginx" ]
+CMD ["-g", "daemon off;"]
+

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,7 +7,6 @@ services:
       - ./conf/nginx.conf:/usr/local/pingos/conf/nginx.conf:ro
       - type: tmpfs
         target: /tmp
-    command: [./sbin/nginx, '-g', 'daemon off;'] 
     network_mode: "host"
     privileged: true
     restart: always


### PR DESCRIPTION
为docker镜像加入`ffmpeg`文件，以便在`nginx.conf`中配置`exec`任务时使用。
使用docker.io中的最大下载量的 `jrottenberg/ffmpeg` 镜像为基础，增加`ENTRYPOINT`指令，修改`CMD`指令。
`docker-compose.yml`文件中删除`command`项，直接使用镜像中的缺省命令即可。